### PR TITLE
sleep 1ms to fix cpu usage>200% for bidder process

### DIFF
--- a/src/com/jacamars/dsp/rtb/bidder/ZPublisher.java
+++ b/src/com/jacamars/dsp/rtb/bidder/ZPublisher.java
@@ -474,6 +474,7 @@ public class ZPublisher implements Runnable, Callback {
                         ping.cancelPing();
                     logger.publish(msg);
                 }
+                Thread.sleep(1);
             } catch (Exception e) {
                 e.printStackTrace();
                 // return;


### PR DESCRIPTION
After I started docker, I found that cpu usage is around 300% which is quite strange. After add the sleep in the while loop, the cpu usage drops to 15%. This is a critical bug.